### PR TITLE
Fix: Improve text contrast in light mode for Markdown preview

### DIFF
--- a/packages/realmd/src/lib/markdown/markdownStyles.ts
+++ b/packages/realmd/src/lib/markdown/markdownStyles.ts
@@ -13,13 +13,13 @@ export const markdownStyles = HighlightStyle.define([
   
   // Lists (other than bullet)
   { tag: tags.list, margin: "8px 0" },
-  { tag: tags.labelName, color: "#e6db74" }, // For definition lists
+  { tag: tags.labelName, color: "var(--ifm-font-color-secondary)" }, // For definition lists
   
   // Horizontal rule
   { tag: tags.processingInstruction, display: "block", borderBottom: "1px solid #555", margin: "12px 0" },
   
   // Inline code
-  { tag: tags.monospace, fontFamily: "monospace", backgroundColor: "rgba(0, 0, 0, 0.3)", padding: "2px 4px", borderRadius: "3px" },
+  { tag: tags.monospace, fontFamily: "monospace", backgroundColor: "var(--ifm-code-background)", padding: "2px 4px", borderRadius: "3px" },
 ]);
 
 // Theme for additional markdown elements
@@ -37,7 +37,7 @@ export const markdownTheme = EditorView.baseTheme({
   
   // Task list styling (for items not covered by checkbox plugin)
   ".cm-meta.cm-list": {
-    color: "#75715e"
+    color: "var(--ifm-font-color-secondary)"
   },
   
   // Text formatting styles


### PR DESCRIPTION
The Markdown preview had several elements with hardcoded colors that resulted in poor text contrast against the light background in light mode. Specifically, inline code backgrounds, label names (e.g., in definition lists), and task list metadata were too light.

This commit modifies `packages/realmd/src/lib/markdown/markdownStyles.ts` to use standard Docusaurus/Infima CSS variables for these elements:
- `tags.monospace` background changed to `var(--ifm-code-background)`.
- `tags.labelName` color changed to `var(--ifm-font-color-secondary)`.
- `".cm-meta.cm-list"` color changed to `var(--ifm-font-color-secondary)`.

These changes ensure that the colors adapt correctly to both light and dark themes, improving readability.

Note: Live testing of this change was hindered by a persistent issue with `pnpm i` failing in my execution environment. However, the fix relies on standard theming variables expected to function correctly.